### PR TITLE
Add :string support for `fetch`

### DIFF
--- a/grafito.art
+++ b/grafito.art
@@ -579,6 +579,8 @@ graph: function [
         ;; ]
         ;; returns: :block
         
+        ;; setup main variables
+
         catchAny?: false
         if? not? null? attr "any" ->
             catchAny?: true
@@ -595,80 +597,97 @@ graph: function [
 
         att: new attributes
 
-        if and? not? dictionary? att 
-                not? null? att ->
-            att: #att
+        if? string? att [
+            [collate,symb,val]: @[collator, "=", as.code att]
+            
+            ; add it once (to check for `name`)
+            'propertyFilters ++ ~propertyWithValueFilter
+            'qpropvals ++ @[~"$.name"]
 
-        ; HACK - to solve
-        remove.key 'att 'n
-        remove.key 'att 'a
+            ; add it once more (to check for `title`)
+            'propertyFilters ++ ~propertyWithValueFilter
+            'qpropvals ++ @[~"$.title"]
 
-        if not? empty? att [
-            loop att [k,v][
-                case [equal? type v]
-                    when? [:null][
-                        ; it's an edge filter without criteria
-                        'edgeFilters ++ hasEdgeFilter
-                        'qedgevals ++ @[k]
-                    ]
-                    when? [:dictionary][
-                        ; it's an edge filter
-                        'edgeFilters ++ edgeWithTargetFilter
-                        'qedgevals ++ @[k, v\id]
-                    ]
-                    when? [:block][
-                        if? and? 0 < size v 
-                                 :dictionary = type first v [
-                            ; it's an array of edge filters
-                            orCriteria: new []
-                            loop v [edgef][
-                                'orCriteria ++ {!sql (edges.tag=? AND edges.target=?)}
-                                'qedgevals ++ @[k, edgef\id]
+            ; we won't it to be valid when any of the two criteria above is true
+            ; so we'll have to forcefully set `catchAny?` to true
+            catchAny?: true
+        ]
+        else [
+            if and? not? dictionary? att 
+                    not? null? att ->
+                att: #att
+
+            ; HACK - to solve
+            remove.key 'att 'n
+            remove.key 'att 'a
+
+            if not? empty? att [
+                loop att [k,v][
+                    case [equal? type v]
+                        when? [:null][
+                            ; it's an edge filter without criteria
+                            'edgeFilters ++ hasEdgeFilter
+                            'qedgevals ++ @[k]
+                        ]
+                        when? [:dictionary][
+                            ; it's an edge filter
+                            'edgeFilters ++ edgeWithTargetFilter
+                            'qedgevals ++ @[k, v\id]
+                        ]
+                        when? [:block][
+                            if? and? 0 < size v 
+                                    :dictionary = type first v [
+                                ; it's an array of edge filters
+                                orCriteria: new []
+                                loop v [edgef][
+                                    'orCriteria ++ {!sql (edges.tag=? AND edges.target=?)}
+                                    'qedgevals ++ @[k, edgef\id]
+                                ]
+                                'edgeFilters ++ "(" ++ (join.with:" OR " orCriteria) ++ ")"
                             ]
-                            'edgeFilters ++ "(" ++ (join.with:" OR " orCriteria) ++ ")"
+                            else [
+                                ; it's a complex property filter
+                                loop #v [filt,rg][
+
+                                    [collate,symb,val]: @[collator, "=", v]
+
+                                    case [equal? filt]
+            
+                                        when? ["contains"]      -> [collate,symb,val]: @["", "LIKE", ~"%|rg|%"]
+                                        when? ["prefix"]        -> [collate,symb,val]: @["", "LIKE", ~"|rg|%"]
+                                        when? ["suffix"]        -> [collate,symb,val]: @["", "LIKE", ~"%|rg|"]
+                                        when? ["under"]         -> [collate,symb,val]: @["", "<", rg]
+                                        when? ["over"]          -> [collate,symb,val]: @["", ">", rg]
+                                        when? ["underOrEqual"]  -> [collate,symb,val]: @["", "<=", rg]
+                                        when? ["overOrEqual"]   -> [collate,symb,val]: @["", ">=", rg]
+                                        when? ["in"]            -> [collate,symb,val]: @[collator, "IN", ~{(|join.with:", " map rg [x]["'" ++ (to :string x) ++ "'"]|)}]
+                                        when? ["not"][     
+                                            if? block? rg       -> [collate,symb,val]: @[collator, "NOT IN", ~{(|join.with:", " map rg [x]["'" ++ (to :string x) ++ "'"]|)}]
+                                            else                -> [collate,symb,val]: @[collator, "!=", rg]
+                                        ]
+                                        else [
+                                            panic.code: 1 ~"filter: |filt| not recognized"
+                                        ]
+                                    
+                                    val: as.code val
+                                    'propertyFilters ++ ~propertyWithValueFilter
+                                    'qpropvals ++ @[~"$.|k|"]
+                                ]
+                            ]
+                        ]
+                        when? [:logical][
+                            ; it's a simple property filter without criteria
+                            'propertyFilters ++ hasPropertyFilter
+                            'qpropvals ++ @[~"$.|k|"]
                         ]
                         else [
-                            ; it's a complex property filter
-                            loop #v [filt,rg][
-
-                                [collate,symb,val]: @[collator, "=", v]
-
-                                case [equal? filt]
-        
-                                    when? ["contains"]      -> [collate,symb,val]: @["", "LIKE", ~"%|rg|%"]
-                                    when? ["prefix"]        -> [collate,symb,val]: @["", "LIKE", ~"|rg|%"]
-                                    when? ["suffix"]        -> [collate,symb,val]: @["", "LIKE", ~"%|rg|"]
-                                    when? ["under"]         -> [collate,symb,val]: @["", "<", rg]
-                                    when? ["over"]          -> [collate,symb,val]: @["", ">", rg]
-                                    when? ["underOrEqual"]  -> [collate,symb,val]: @["", "<=", rg]
-                                    when? ["overOrEqual"]   -> [collate,symb,val]: @["", ">=", rg]
-                                    when? ["in"]            -> [collate,symb,val]: @[collator, "IN", ~{(|join.with:", " map rg [x]["'" ++ (to :string x) ++ "'"]|)}]
-                                    when? ["not"][     
-                                        if? block? rg       -> [collate,symb,val]: @[collator, "NOT IN", ~{(|join.with:", " map rg [x]["'" ++ (to :string x) ++ "'"]|)}]
-                                        else                -> [collate,symb,val]: @[collator, "!=", rg]
-                                    ]
-                                    else [
-                                        panic.code: 1 ~"filter: |filt| not recognized"
-                                    ]
-                                
-                                val: as.code val
-                                'propertyFilters ++ ~propertyWithValueFilter
-                                'qpropvals ++ @[~"$.|k|"]
-                            ]
+                            ; it's a simple property filter
+                            [collate,symb,val]: @[collator, "=", as.code v]
+            
+                            'propertyFilters ++ ~propertyWithValueFilter
+                            'qpropvals ++ @[~"$.|k|"]
                         ]
-                    ]
-                    when? [:logical][
-                        ; it's a simple property filter without criteria
-                        'propertyFilters ++ hasPropertyFilter
-                        'qpropvals ++ @[~"$.|k|"]
-                    ]
-                    else [
-                        ; it's a simple property filter
-                        [collate,symb,val]: @[collator, "=", as.code v]
-        
-                        'propertyFilters ++ ~propertyWithValueFilter
-                        'qpropvals ++ @[~"$.|k|"]
-                    ]
+                ]
             ]
         ]
 

--- a/grafito.art
+++ b/grafito.art
@@ -571,7 +571,7 @@ graph: function [
 
     fetch: function [
         name :literal :string
-        attributes :null :block :dictionary
+        attributes :null :string :block :dictionary
     ][
         ;; description: « retrieves nodes with name that match all given attributes
         ;; options: [

--- a/grafito.art
+++ b/grafito.art
@@ -21,7 +21,7 @@ Grafito: #[
     Version: 0.2.8
 
     ; configuration
-    Debug?: true
+    Debug?: false
     verbose?: true
     caseSensitive?: false
 ]

--- a/grafito.art
+++ b/grafito.art
@@ -21,7 +21,7 @@ Grafito: #[
     Version: 0.2.8
 
     ; configuration
-    Debug?: false
+    Debug?: true
     verbose?: true
     caseSensitive?: false
 ]

--- a/grafito.art
+++ b/grafito.art
@@ -583,6 +583,16 @@ graph: function [
         if? not? null? attr "any" ->
             catchAny?: true
 
+        collator: ""
+        if not? Grafito\caseSensitive? ->
+            collator: " COLLATE NOCASE"
+
+        propertyFilters: new []
+        edgeFilters: new []
+        qvals: new @[name]
+        qpropvals: new []
+        qedgevals: new []
+
         att: new attributes
 
         if and? not? dictionary? att 
@@ -592,16 +602,6 @@ graph: function [
         ; HACK - to solve
         remove.key 'att 'n
         remove.key 'att 'a
-
-        propertyFilters: new []
-        edgeFilters: new []
-        qvals: new @[name]
-        qpropvals: new []
-        qedgevals: new []
-
-        collator: ""
-        if not? Grafito\caseSensitive? ->
-            collator: " COLLATE NOCASE"
 
         if not? empty? att [
             loop att [k,v][


### PR DESCRIPTION
It would be great if `fetch`, instead of an array of attributes could also take a string (or literal?) against a pre-defined(?) record field, e.g. *name* or *title*.

**For example:**

```red
fetch'person [name: "John"]
```

**would be equivalent to:**

```red
fetch'person "John"
```

This would help make longer queries less verbose and less visually-cluttered.

-----

**Compare this:** (even when using helpers)

```red
person [actedIn: movie [title: "Memento"], isFrom: country [name: "Australia"]]
```

**To this:**

```red
person [actedIn: movie "Memento", isFrom: country "Australia"]
```