### PR TITLE
WIP: Make node/edge labels & property names case-insensitive

### DIFF
--- a/grafito.art
+++ b/grafito.art
@@ -182,11 +182,11 @@ graph: function [
         ;; description: « create edge from source to target node with given name
         ;; returns: :dictionary
 
-        edgeId: performQuery.id 'edge createEdgeSQL @[name, src\id, tgt\id]
+        edgeId: performQuery.id 'edge createEdgeSQL @[lower name, src\id, tgt\id]
 
         #[
             id: edgeId
-            tag: name
+            tag: lower name
             source: src
             target: tgt
         ]
@@ -203,7 +203,7 @@ graph: function [
     ][
         ;; description: « delete edge from source to target node with given name
 
-        performQuery 'unedge deleteEdgeSQL @[name, src, tgt]
+        performQuery 'unedge deleteEdgeSQL @[lower name, src, tgt]
     ]
 
         ;
@@ -365,10 +365,10 @@ graph: function [
                 att: nd
                 if not? dictionary? att -> att: #att
                 'queries ++ createNodeSQL
-                'vals ++ @[name, write.json ø att]
+                'vals ++ @[lower name, write.json ø att]
                 'result ++ #[
                     id: lastId
-                    tag: name
+                    tag: lower name
                     properties: att
                 ]
             ]
@@ -380,10 +380,10 @@ graph: function [
         else [
             att: attributes
             if not? dictionary? att -> att: #att
-            nodeId: performQuery.id 'put createNodeSQL @[name, write.json ø att]
+            nodeId: performQuery.id 'put createNodeSQL @[lower name, write.json ø att]
             result: #[
                 id: nodeId
-                tag: name
+                tag: lower name
                 properties: att
             ]
 
@@ -595,7 +595,7 @@ graph: function [
 
         propertyFilters: new []
         edgeFilters: new []
-        qvals: new @[name]
+        qvals: new @[lower name]
         qpropvals: new []
         qedgevals: new []
 

--- a/grafito.art
+++ b/grafito.art
@@ -182,11 +182,13 @@ graph: function [
         ;; description: « create edge from source to target node with given name
         ;; returns: :dictionary
 
-        edgeId: performQuery.id 'edge createEdgeSQL @[lower name, src\id, tgt\id]
+        nameT: lower to :string name
+
+        edgeId: performQuery.id 'edge createEdgeSQL @[nameT, src\id, tgt\id]
 
         #[
             id: edgeId
-            tag: lower name
+            tag: nameT
             source: src
             target: tgt
         ]
@@ -203,7 +205,9 @@ graph: function [
     ][
         ;; description: « delete edge from source to target node with given name
 
-        performQuery 'unedge deleteEdgeSQL @[lower name, src, tgt]
+        nameT: lower to :string name
+
+        performQuery 'unedge deleteEdgeSQL @[nameT, src, tgt]
     ]
 
         ;
@@ -349,8 +353,10 @@ graph: function [
         ;; ]
         ;; returns: :dictionary :block
 
+        nameT: lower to :string name
+
         if attr "unique" [
-            found: fetch name attributes
+            found: fetch nameT attributes
             if not? empty? found -> return found
         ]
 
@@ -365,10 +371,10 @@ graph: function [
                 att: nd
                 if not? dictionary? att -> att: #att
                 'queries ++ createNodeSQL
-                'vals ++ @[lower name, write.json ø att]
+                'vals ++ @[nameT, write.json ø att]
                 'result ++ #[
                     id: lastId
-                    tag: lower name
+                    tag: nameT
                     properties: att
                 ]
             ]
@@ -380,10 +386,10 @@ graph: function [
         else [
             att: attributes
             if not? dictionary? att -> att: #att
-            nodeId: performQuery.id 'put createNodeSQL @[lower name, write.json ø att]
+            nodeId: performQuery.id 'put createNodeSQL @[nameT, write.json ø att]
             result: #[
                 id: nodeId
-                tag: lower name
+                tag: nameT
                 properties: att
             ]
 
@@ -593,9 +599,11 @@ graph: function [
         if not? Grafito\caseSensitive? ->
             collator: " COLLATE NOCASE"
 
+        nameT: lower to :string name
+
         propertyFilters: new []
         edgeFilters: new []
-        qvals: new @[lower name]
+        qvals: new @[nameT]
         qpropvals: new []
         qedgevals: new []
 

--- a/grafito.art
+++ b/grafito.art
@@ -369,7 +369,7 @@ graph: function [
             loop attributes 'nd [
                 lastId: lastId + 1
                 att: nd
-                if not? dictionary? att -> att: #att
+                if not? dictionary? att -> att: #.lower att
                 'queries ++ createNodeSQL
                 'vals ++ @[nameT, write.json ø att]
                 'result ++ #[
@@ -385,7 +385,7 @@ graph: function [
         ]
         else [
             att: attributes
-            if not? dictionary? att -> att: #att
+            if not? dictionary? att -> att: #.lower att
             nodeId: performQuery.id 'put createNodeSQL @[nameT, write.json ø att]
             result: #[
                 id: nodeId
@@ -428,7 +428,7 @@ graph: function [
 
         additional: attributes
         if block? additional ->
-            additional: # additional
+            additional: #.lower additional
 
         loop toUpdate 'updateable [
             newAttributes: ø
@@ -627,7 +627,7 @@ graph: function [
         else [
             if and? not? dictionary? att 
                     not? null? att ->
-                att: #att
+                att: #.lower att
 
             ; HACK - to solve
             remove.key 'att 'n


### PR DESCRIPTION
Having a `person`, `Person`, `PERSON` types of nodes and all of these meaning something different doesn't make a lot of sense.

The same could be said for property names.

----

Related: https://github.com/arturo-lang/arturo/commit/6c51de602d3fa63fd995d9724430ae853f9e6ca0