### PR TITLE
Add .gitattributes for GitHub file highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.art linguist-language=Red

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.art linguist-language=Red
+*.art linguist-vendored


### PR DESCRIPTION
Render files on GitHub using the same Red linguist grammar as used in Markdown files