### PR TITLE
Implement undirected edges

### DIFF
--- a/grafito.art
+++ b/grafito.art
@@ -1098,6 +1098,7 @@ graph: function [
 
     ; define aliases
     alias.infix {~>} 'link
+    alias.infix {<~} 'reverseLink
 
     ; open the database
     printDebug ~"DB = |cleanpath|"

--- a/grafito.art
+++ b/grafito.art
@@ -634,6 +634,14 @@ graph: function [
         ]
     ]
 
+    reverseLink: function [
+        tgt :block :dictionary
+        name :literal :string
+        src :block :dictionary
+    ][
+        link src name tgt
+    ]
+
     ;
     ; Delete node edges
     ;--------------------------


### PR DESCRIPTION
Right now, `link` (and thus `~>`) can only create directed edges/links (from node A to node B).

However, internally - as things are right now, at least - we could also support either reverse links (the ability to define edge from B to A, using a simple syntax like `A <~ B` and also reciprocal/undirected edges, like `A <~> B`).