### PR TITLE
Add support for reverse edge filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center"><img width="90%" align="center" src="https://raw.githubusercontent.com/arturo-lang/grafito/master/ui-screenshot.png"/></p>
 
 --- 
-
+ 
 <!--ts-->
 
 * [At A Glance](#at-a-glance)

--- a/grafito.art
+++ b/grafito.art
@@ -1133,6 +1133,10 @@ graph: function [
     alias.infix {<~} 'reverseLink
     alias.infix {<~>} 'reciprocalLink
 
+    alias {|>} 'edgeFilterRight
+    alias {<|} 'edgeFilterLeft
+    alias {<|>} 'edgeFilterBoth
+
     ; open the database
     printDebug ~"DB = |cleanpath|"
     db: open dbPath

--- a/grafito.art
+++ b/grafito.art
@@ -819,6 +819,25 @@ graph: function [
                         'qedgevals ++ @[k, v\id]
                         continue
                     ]
+                    if is? :edgeFilter v [
+                        ; it's a directed edge filter
+                        (v\direction = 1)? [
+                            'edgeFilters ++ edgeWithTargetFilter
+                            'qedgevals ++ @[k, v\content\id]
+                        ][
+                            (v\direction = 2)? [
+                                'edgeFilters ++ edgeWithSourceFilter
+                                'qedgevals ++ @[k, v\content\id]
+                            ][
+                                (v\direction = 3)? -> [
+                                    'edgeFilters ++ edgeWithAnyFilter 
+                                    'qedgevals ++ @[k, v\content\id, v\content\id]]
+                                ][
+                                    print "Shouldn't have reached here!"
+                                ]
+                            ]
+                        ]
+                    ]
                     if block? v [
                         (and? 0 < size v 
                                 :dictionary = type first v)? [

--- a/grafito.art
+++ b/grafito.art
@@ -732,6 +732,22 @@ graph: function [
     ]
 
     ;
+    ; Helpers
+    ; for edge filters
+    ;--------------------------
+    edgeFilterRight: function [cnt][
+        to :edgeFilter @[1, cnt]
+    ]
+
+    edgeFilterLeft: function [cnt][
+        to :edgeFilter @[2, cnt]
+    ]
+
+    edgeFilterBoth: function [cnt][
+        to :edgeFilter @[3, cnt]
+    ]
+
+    ;
     ; Fetch all results for tag
     ; with given properties
     ; and edges

--- a/grafito.art
+++ b/grafito.art
@@ -738,14 +738,17 @@ graph: function [
     ; for edge filters
     ;--------------------------
     edgeFilterRight: function [cnt][
+        print "in edgeFilterRight"
         to :edgeFilter @[1, cnt]
     ]
 
     edgeFilterLeft: function [cnt][
+        print "in edgeFilterLeft"
         to :edgeFilter @[2, cnt]
     ]
 
     edgeFilterAny: function [cnt][
+        print "in edgeFilterBoth"
         to :edgeFilter @[3, cnt]
     ]
 
@@ -823,23 +826,51 @@ graph: function [
                     ]
                     if is? :edgeFilter v [
                         ; it's a directed edge filter
-                        (v\direction = 1)? [
-                            'edgeFilters ++ edgeWithTargetFilter
-                            'qedgevals ++ @[k, v\content\id]
-                        ][
-                            (v\direction = 2)? [
-                                'edgeFilters ++ edgeWithSourceFilter
+                        if dictionary? v\content [
+                            (v\direction = 1)? [
+                                'edgeFilters ++ edgeWithTargetFilter
                                 'qedgevals ++ @[k, v\content\id]
                             ][
-                                (v\direction = 3)? [
-                                    'edgeFilters ++ edgeWithAnyFilter 
-                                    'qedgevals ++ @[k, v\content\id, v\content\id]
+                                (v\direction = 2)? [
+                                    'edgeFilters ++ edgeWithSourceFilter
+                                    'qedgevals ++ @[k, v\content\id]
                                 ][
-                                    print "Shouldn't have reached here!"
+                                    (v\direction = 3)? [
+                                        'edgeFilters ++ edgeWithAnyFilter 
+                                        'qedgevals ++ @[k, v\content\id, v\content\id]
+                                    ][
+                                        print "Shouldn't have reached here!"
+                                    ]
                                 ]
                             ]
+                            continue
                         ]
-                        continue
+                        if all? @[
+                            block? v\content
+                            0 < size v\content
+                            :dictionary = type first v\content
+                        ][
+                            orCriteria: new []
+                            loop v\content [edgef][
+                                (v\direction = 1)? [
+                                    'orCriteria ++ edgeWithTargetFilter
+                                    'qedgevals ++ @[k, edgef\id]
+                                ][
+                                    (v\direction = 2)? [
+                                        'orCriteria ++ edgeWithSourceFilter
+                                        'qedgevals ++ @[k, edgef\id]
+                                    ][
+                                        (v\direction = 3)? [
+                                            'orCriteria ++ edgeWithAnyFilter 
+                                            'qedgevals ++ @[k, edgef\id, edgef\id]
+                                        ][
+                                            print "Shouldn't have reached here!"
+                                        ]
+                                    ]
+                                ]
+                            ]
+                            'edgeFilters ++ "(" ++ (join.with:" OR " orCriteria) ++ ")"
+                        ]
                     ]
                     if block? v [
                         (and? 0 < size v 
@@ -847,7 +878,7 @@ graph: function [
                             ; it's an array of edge filters
                             orCriteria: new []
                             loop v [edgef][
-                                'orCriteria ++ {!sql (edges.tag=? AND edges.target=?)}
+                                'orCriteria ++ edgesWithTargetFilter
                                 'qedgevals ++ @[k, edgef\id]
                             ]
                             'edgeFilters ++ "(" ++ (join.with:" OR " orCriteria) ++ ")"

--- a/grafito.art
+++ b/grafito.art
@@ -126,8 +126,6 @@ graph: function [
     ;--------------------------
 
     performQuery: function [ctx, qu, params][
-        print qu
-        print "---"
         if and? [Grafito\Debug?][null? attr 'noDebug] [
             context: to :string ctx
             prepend: " | "
@@ -740,17 +738,14 @@ graph: function [
     ; for edge filters
     ;--------------------------
     edgeFilterRight: function [cnt][
-        print "in edgeFilterRight"
         to :edgeFilter @[1, cnt]
     ]
 
     edgeFilterLeft: function [cnt][
-        print "in edgeFilterLeft"
         to :edgeFilter @[2, cnt]
     ]
 
     edgeFilterAny: function [cnt][
-        print "in edgeFilterBoth"
         to :edgeFilter @[3, cnt]
     ]
 

--- a/grafito.art
+++ b/grafito.art
@@ -831,7 +831,7 @@ graph: function [
                                 'edgeFilters ++ edgeWithSourceFilter
                                 'qedgevals ++ @[k, v\content\id]
                             ][
-                                (v\direction = 3)? -> [
+                                (v\direction = 3)? [
                                     'edgeFilters ++ edgeWithAnyFilter 
                                     'qedgevals ++ @[k, v\content\id, v\content\id]]
                                 ][

--- a/grafito.art
+++ b/grafito.art
@@ -839,6 +839,7 @@ graph: function [
                                 ]
                             ]
                         ]
+                        continue
                     ]
                     if block? v [
                         (and? 0 < size v 

--- a/grafito.art
+++ b/grafito.art
@@ -878,7 +878,7 @@ graph: function [
                             ; it's an array of edge filters
                             orCriteria: new []
                             loop v [edgef][
-                                'orCriteria ++ edgesWithTargetFilter
+                                'orCriteria ++ edgeWithTargetFilter
                                 'qedgevals ++ @[k, edgef\id]
                             ]
                             'edgeFilters ++ "(" ++ (join.with:" OR " orCriteria) ++ ")"

--- a/grafito.art
+++ b/grafito.art
@@ -833,7 +833,7 @@ graph: function [
                             ][
                                 (v\direction = 3)? [
                                     'edgeFilters ++ edgeWithAnyFilter 
-                                    'qedgevals ++ @[k, v\content\id, v\content\id]]
+                                    'qedgevals ++ @[k, v\content\id, v\content\id]
                                 ][
                                     print "Shouldn't have reached here!"
                                 ]

--- a/grafito.art
+++ b/grafito.art
@@ -97,6 +97,8 @@ graph: function [
     hasEdgeFilter:              read "sql/filters/hasEdge.sql"
     hasPropertyFilter:          read "sql/filters/hasProperty.sql"
     edgeWithTargetFilter:       read "sql/filters/edgeWithTarget.sql"
+    edgeWithSourceFilter:       read "sql/filters/edgeWithSource.sql"
+    edgeWithAnyFilter:          read "sql/filters/edgeWithAny.sql"
     propertyWithValueFilter:    read "sql/filters/propertyWithValue.sql"
 
     ; Global SQL pragmas

--- a/grafito.art
+++ b/grafito.art
@@ -33,6 +33,13 @@ Grafito: #[
     Palette: ""
 ]
 
+;
+; Define custom objects
+;--------------------------
+define :edgeFilter [direction, content][]
+
+;----------------------------------------------
+
 graph: function [
     dbpath :string :null
     body :block

--- a/grafito.art
+++ b/grafito.art
@@ -126,6 +126,8 @@ graph: function [
     ;--------------------------
 
     performQuery: function [ctx, qu, params][
+        print qu
+        print "---"
         if and? [Grafito\Debug?][null? attr 'noDebug] [
             context: to :string ctx
             prepend: " | "
@@ -843,7 +845,6 @@ graph: function [
                                     ]
                                 ]
                             ]
-                            continue
                         ]
                         if all? @[
                             block? v\content
@@ -871,6 +872,7 @@ graph: function [
                             ]
                             'edgeFilters ++ "(" ++ (join.with:" OR " orCriteria) ++ ")"
                         ]
+                        continue
                     ]
                     if block? v [
                         (and? 0 < size v 

--- a/grafito.art
+++ b/grafito.art
@@ -743,7 +743,7 @@ graph: function [
         to :edgeFilter @[2, cnt]
     ]
 
-    edgeFilterBoth: function [cnt][
+    edgeFilterAny: function [cnt][
         to :edgeFilter @[3, cnt]
     ]
 
@@ -1154,7 +1154,7 @@ graph: function [
 
     alias {|>} 'edgeFilterRight
     alias {<|} 'edgeFilterLeft
-    alias {<|>} 'edgeFilterBoth
+    alias {<|>} 'edgeFilterAny
 
     ; open the database
     printDebug ~"DB = |cleanpath|"

--- a/sql/filters/edgeWithAny.sql
+++ b/sql/filters/edgeWithAny.sql
@@ -1,0 +1,1 @@
+(edges.tag=? AND (edges.target=? OR edges.source=?))

--- a/sql/filters/edgeWithSource.sql
+++ b/sql/filters/edgeWithSource.sql
@@ -1,0 +1,1 @@
+(edges.tag=? AND edges.source=?)

--- a/sql/procs/fetchNodes.withEdges.sql
+++ b/sql/procs/fetchNodes.withEdges.sql
@@ -1,7 +1,7 @@
 SELECT nodes.id, nodes.tag, nodes.properties
 FROM nodes
 INNER JOIN edges
-ON edges.source=nodes.id
+ON edges.source=nodes.id OR edges.target=nodes.id
 WHERE nodes.tag=? |propies|
 GROUP BY nodes.id 
 HAVING COUNT( 


### PR DESCRIPTION
Let's take the famous [sample11.art](https://github.com/arturo-lang/grafito/blob/main/examples/sample11.art).

So..., we have a graph with actors, where they are from, which countries they have acted in, etc.

Right now, to get e.g. the Person(s?) that has directed the Movie with the title "Mystic River" we could perform the following query:

<img width="1034" alt="Screenshot 2023-11-02 at 12 00 38" src="https://github.com/arturo-lang/grafito/assets/1265028/4090f898-74ea-40fc-924a-87dab66a44f3">

And the results are the ones we'd expect.

Now, given that `directed` is an edge that goes from a Person ➡ to a Movie, querying like this is fine.

But what if we want the reverse thing? For example: find the Movie's that were directed *by* a given Person?

One way would be to make the edge bi-directional (in a few words: "Mystic River" pointing ➡ to Eastwoord and Eastwood pointing back ⬅️ to "Mystic River"). But that completely defeats the purpose of having direction-aware edges and the meaningfulness of it all.

So, basically, right now, there is simply no way to - elegantly - perform this type of seemingly ultra-logical query.

So? Let's find a way! 🚀 