### PR TITLE
Add better support for Unicode data properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center"><img width="90%" align="center" src="https://raw.githubusercontent.com/arturo-lang/grafito/master/ui-screenshot.png"/></p>
 
 --- 
- 
+
 <!--ts-->
 
 * [At A Glance](#at-a-glance)

--- a/grafito.art
+++ b/grafito.art
@@ -236,7 +236,7 @@ graph: function [
     ;--------------------------
     codifySafe: function [val][
         (string? val)? [
-            return "+" + (escape.json val) + "+"
+            return "+" ++ (escape.json val) ++ "+"
         ][
             return as.code val
         ]

--- a/grafito.art
+++ b/grafito.art
@@ -236,7 +236,7 @@ graph: function [
     ;--------------------------
     codifySafe: function [val][
         (string? val)? [
-            return "+" ++ (escape.json val) ++ "+"
+            return {"} ++ (escape.json val) ++ {"}
         ][
             return as.code val
         ]

--- a/grafito.art
+++ b/grafito.art
@@ -236,7 +236,7 @@ graph: function [
     ;--------------------------
     codifySafe: function [val][
         (string? val)? [
-
+            return "+" + (escape.json val) + "+"
         ][
             return as.code val
         ]

--- a/grafito.art
+++ b/grafito.art
@@ -230,6 +230,19 @@ graph: function [
     ]
 
     ;
+    ; Safe SQLite-compatible
+    ; value codification
+    ; including Unicode strings
+    ;--------------------------
+    codifySafe: function [val][
+        (string? val)? [
+
+        ][
+            return as.code val
+        ]
+    ]
+
+    ;
     ; Get styled node
     ; ready for use in the
     ; graph view
@@ -784,7 +797,7 @@ graph: function [
         att: new attributes
 
         (string? att)? [
-            [collate,symb,val]: @[collator, "=", as.code att]
+            [collate,symb,val]: @[collator, "=", codifySafe att]
             
             ; add it once (to check for `name`)
             'propertyFilters ++ ~propertyWithValueFilter
@@ -935,7 +948,7 @@ graph: function [
                                 ;         panic.code: 1 ~"filter: |filt| not recognized"
                                 ;     ]
                                 
-                                val: as.code val
+                                val: codifySafe val
                                 'propertyFilters ++ ~propertyWithValueFilter
                                 'qpropvals ++ @[~"$.|k|"]
                             ]
@@ -950,7 +963,7 @@ graph: function [
                     ]
                         
                     ; it's a simple property filter
-                    [collate,symb,val]: @[collator, "=", as.code v]
+                    [collate,symb,val]: @[collator, "=", codifySafe v]
     
                     'propertyFilters ++ ~propertyWithValueFilter
                     'qpropvals ++ @[~"$.|k|"]


### PR DESCRIPTION
Basically, right now, whenever we use a field (even a node name) which contains non pure-ASCII character, the result becomes a mess and we cannot properly query the graph.

This is mostly due to this: https://github.com/arturo-lang/arturo/issues/1289

Or - better put - due to my erroneous use of `as.code` before transforming some fields that - while not possible to be put into a prepared statement - they will still end up inside an SQL statement. So, bingo!