### PR TITLE
Make `put` work with strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center"><img width="90%" align="center" src="https://raw.githubusercontent.com/arturo-lang/grafito/master/ui-screenshot.png"/></p>
 
 --- 
-
+ 
 <!--ts-->
 
 * [At A Glance](#at-a-glance)

--- a/grafito.art
+++ b/grafito.art
@@ -480,7 +480,7 @@ graph: function [
     
     put: function [
         name :literal :string
-        attributes :block :dictionary
+        attributes :string :block :dictionary
     ][
         ;; description: « insert new node(s) to graph with given name and attributes
         ;; options: [
@@ -503,7 +503,12 @@ graph: function [
             loop attributes 'nd [
                 lastId: lastId + 1
                 att: nd
-                if not? dictionary? att -> att: # att
+                (block? att)? -> att: # att [
+                    (string? att)? -> att: #[
+                        name: att
+                    ] []
+                ]
+                ;if not? dictionary? att -> att: # att
                 'queries ++ createNodeSQL
                 'vals ++ @[name, write.compact.json ø att]
                 'result ++ #[
@@ -518,7 +523,12 @@ graph: function [
                  printDebug ~{created |size attributes| nodes}
         ] [
             att: attributes
-            if not? dictionary? att -> att: # att
+            (block? att)? -> att: # att [
+                (string? att)? -> att: #[
+                    name: att
+                ] []
+            ]
+            ; if not? dictionary? att -> att: # att
             nodeId: performQuery.id 'put createNodeSQL @[name, write.compact.json ø att]
             result: #[
                 id: nodeId

--- a/grafito.art
+++ b/grafito.art
@@ -508,7 +508,6 @@ graph: function [
                         name: att
                     ] []
                 ]
-                ;if not? dictionary? att -> att: # att
                 'queries ++ createNodeSQL
                 'vals ++ @[name, write.compact.json ø att]
                 'result ++ #[
@@ -528,7 +527,6 @@ graph: function [
                     name: att
                 ] []
             ]
-            ; if not? dictionary? att -> att: # att
             nodeId: performQuery.id 'put createNodeSQL @[name, write.compact.json ø att]
             result: #[
                 id: nodeId


### PR DESCRIPTION
Pretty much like:

```
fetch 'person [name: "John"]
```
and
```
person "John"
```
are equivalent.

-------

In our case, the goal is the equivalence between:

```
put 'person [name: "John"]
```

and

```
person.new "John"
```