### PR TITLE
Fix `in` & `not` filters

### DIFF
--- a/grafito.art
+++ b/grafito.art
@@ -906,6 +906,7 @@ graph: function [
                             loop # v [filt,rg][
 
                                 [collate,symb,val]: @[collator, "=", v]
+                                requiresCodification: true
 
                                 (filt = "contains")? -> [collate,symb,val]: @["", "LIKE", ~"%|rg|%"]
                                 [
@@ -921,10 +922,15 @@ graph: function [
                                                     [
                                                         (filt = "overOrEqual")? -> [collate,symb,val]: @["", ">=", rg]
                                                         [
-                                                            (filt = "in")? -> [collate,symb,val]: @[collator, "IN", ~{(|join.with:", " map rg [x]["'" ++ (to :string x) ++ "'"]|)}]
-                                                            [
+                                                            (filt = "in")? [
+                                                                [collate,symb,val]: @[collator, "IN", "(" ++ (join.with:", " map rg [x][codifySafe x]) ++ ")"]
+                                                                requiresCodification: false
+                                                            ][
                                                                 (filt = "not")? [ 
-                                                                    (block? rg)?       -> [collate,symb,val]: @[collator, "NOT IN", ~{(|join.with:", " map rg [x]["'" ++ (to :string x) ++ "'"]|)}]
+                                                                    (block? rg)?       [
+                                                                                          [collate,symb,val]: @[collator, "NOT IN", "(" ++ (join.with:", " map rg [x][codifySafe x]) ++ ")"]
+                                                                                          requiresCodification: false
+                                                                                       ]
                                                                                        -> [collate,symb,val]: @[collator, "!=", rg]
                                                                 ]
                                                                 [
@@ -956,7 +962,8 @@ graph: function [
                                 ;         panic.code: 1 ~"filter: |filt| not recognized"
                                 ;     ]
                                 
-                                val: codifySafe val
+                                if requiresCodification ->
+                                    val: codifySafe val
                                 'propertyFilters ++ ~propertyWithValueFilter
                                 'qpropvals ++ @[~"$.|k|"]
                             ]

--- a/grafito.art
+++ b/grafito.art
@@ -25,7 +25,7 @@ Grafito: #[
     Version: 0.2.8
 
     ; configuration
-    Debug?: false
+    Debug?: true
     verbose?: true
     caseSensitive?: true
 

--- a/grafito.art
+++ b/grafito.art
@@ -25,7 +25,7 @@ Grafito: #[
     Version: 0.2.8
 
     ; configuration
-    Debug?: true
+    Debug?: false
     verbose?: true
     caseSensitive?: true
 


### PR DESCRIPTION
Right now, none of the queries below work as expected. 

**Find all people whose birthday (year) is either 1960 or 1980:**

```red
person [
    birthday: -> in: [1960, 1980]
]
```

**Find all people whose birthday (year) is between 1960 and 1965:** (how neat does this look!)
```red
person [
    birthday: -> in: 1960..1965
]
```

**Find all people whose birthday (year) is neither 1970 nor 1974:**
```red
person [
    birthday: -> not: [1970, 1974]
]
```